### PR TITLE
[TaxonomyPicker] Allow adding of terms in the taxonomy dialog

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-2021-06-10-15-05-45-feature-taxonomy-dialog-addterms.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-2021-06-10-15-05-45-feature-taxonomy-dialog-addterms.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Allow adding of terms in the TaxonomyPicker Dialog",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch",
+  "date": "2021-06-10T13:05:45.341Z"
+}

--- a/packages/dw-react-controls/.npmrc
+++ b/packages/dw-react-controls/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.pkg.github.com/dlw-digitalworkplace

--- a/packages/dw-react-controls/package.json
+++ b/packages/dw-react-controls/package.json
@@ -30,6 +30,7 @@
 		"@storybook/core-events": "^6.0.22",
 		"@storybook/react": "^6.0.22",
 		"@testing-library/react": "^11.1.0",
+		"@testing-library/user-event": "^13.1.9",
 		"@types/jest": "^26.0.14",
 		"@types/node": "^14.11.8",
 		"@types/react": "^16.9.51",

--- a/packages/dw-react-controls/package.json
+++ b/packages/dw-react-controls/package.json
@@ -52,6 +52,7 @@
 	},
 	"dependencies": {
 		"clsx": "^1.1.1",
+		"rfdc": "^1.3.0",
 		"ts-node": "^9.0.0"
 	},
 	"peerDependencies": {

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -2,7 +2,7 @@ import { IconButton } from "office-ui-fabric-react/lib/Button";
 import { Label } from "office-ui-fabric-react/lib/Label";
 import { classNamesFunction } from "office-ui-fabric-react/lib/Utilities";
 import * as React from "react";
-import { ITermValue } from "../../models";
+import { ITermCreationResult, ITermValue } from "../../models";
 import { ITerm } from "../../models/ITerm";
 import { TermPicker } from "../TermPicker";
 import { ITaxonomyPickerProps, ITaxonomyPickerStyleProps, ITaxonomyPickerStyles } from "./TaxonomyPicker.types";
@@ -11,6 +11,7 @@ import { TaxonomyPickerDialog } from "./TaxonomyPickerDialog";
 const getClassNames = classNamesFunction<ITaxonomyPickerStyleProps, ITaxonomyPickerStyles>();
 
 export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
+	allowAddingTerms,
 	className,
 	disabled,
 	itemLimit,
@@ -45,6 +46,22 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 
 	const handleDialogDismiss = (): void => {
 		setDialogIsOpen(false);
+	};
+
+	const handleCreateNewTerm = async (parentNodeId: string, newValue: string): Promise<void | ITermCreationResult> => {
+		try {
+			const newTerm = await provider.createTerm(parentNodeId, newValue);
+
+			return {
+				success: true,
+				newTerm
+			};
+		} catch (err) {
+			return {
+				success: false,
+				error: err.message
+			};
+		}
 	};
 
 	const onResolveSuggestions = async (filter: string, currentSelection?: ITerm[]): Promise<ITerm[]> => {
@@ -85,9 +102,11 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 				<TaxonomyPickerDialog
 					{...dialogProps}
 					provider={provider}
+					allowAddingTerms={allowAddingTerms}
 					defaultSelectedItems={selectedItems}
 					hidden={!dialogIsOpen}
 					itemLimit={itemLimit}
+					onCreateNewTerm={handleCreateNewTerm}
 					onConfirm={handleDialogConfirm}
 					onDismiss={handleDialogDismiss}
 					pickerProps={{ onResolveSuggestions: onResolveSuggestions }}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
@@ -19,7 +19,7 @@ storiesOf("TaxonomyPicker", module)
 					required={true}
 					selectedItems={selectedItems}
 					onChange={setSelectedItems}
-					itemLimit={1}
+					itemLimit={3}
 					allowAddingTerms={true}
 					dialogProps={{
 						title: "Browse terms",

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
@@ -1,15 +1,32 @@
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { ITermValue } from "../../models";
+import { useStateIfMounted } from "../../utils";
 import { MockTaxonomyProvider } from "./providers";
 import { TaxonomyPicker } from "./TaxonomyPicker";
 
 storiesOf("TaxonomyPicker", module)
 	.addParameters({ component: TaxonomyPicker })
 	.add("Basic", () => {
-		const [selectedItems, setSelectedItems] = React.useState<ITermValue[]>([]);
+		const [selectedItems, setSelectedItems] = useStateIfMounted<ITermValue[]>([]);
 
 		const taxonomyProvider = new MockTaxonomyProvider();
+
+		const getErrorMessage = React.useCallback((error: string) => {
+			return (
+				<>
+					<b>Error:&nbsp;</b> {error}
+				</>
+			);
+		}, []);
+
+		const getSuccessMessage = React.useCallback((message: string, newValue: string) => {
+			return (
+				<>
+					<b>Success:&nbsp;</b> {message} (term: {newValue})
+				</>
+			);
+		}, []);
 
 		return (
 			<div>
@@ -17,7 +34,7 @@ storiesOf("TaxonomyPicker", module)
 					label={"Choose a value"}
 					provider={taxonomyProvider}
 					required={true}
-					selectedItems={selectedItems}
+					selectedItems={selectedItems || []}
 					onChange={setSelectedItems}
 					itemLimit={3}
 					allowAddingTerms={true}
@@ -30,6 +47,8 @@ storiesOf("TaxonomyPicker", module)
 								"Browse for terms in the term tree to find the item you are looking for. Don't forget to Add it to the picker!"
 						}
 					}}
+					onGetErrorMessage={getErrorMessage}
+					onGetSuccessMessage={getSuccessMessage}
 				/>
 
 				<div style={{ marginTop: "8px" }}>

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.stories.tsx
@@ -20,12 +20,15 @@ storiesOf("TaxonomyPicker", module)
 					selectedItems={selectedItems}
 					onChange={setSelectedItems}
 					itemLimit={1}
+					allowAddingTerms={true}
 					dialogProps={{
 						title: "Browse terms",
-						subText:
-							"Browse for terms in the term tree to find the item you are looking for. Don't forget to Add it to the picker!",
 						showRootNode: true,
-						rootNodeLabel: "My terms"
+						rootNodeLabel: "My terms",
+						dialogContentProps: {
+							subText:
+								"Browse for terms in the term tree to find the item you are looking for. Don't forget to Add it to the picker!"
+						}
 					}}
 				/>
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.styles.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.styles.ts
@@ -1,12 +1,16 @@
+import { AnimationClassNames } from "office-ui-fabric-react/lib/Styling";
 import { ITaxonomyPickerStyleProps, ITaxonomyPickerStyles } from "./TaxonomyPicker.types";
 
 const GlobalClassNames = {
 	taxonomyPicker: "dw-TaxonomyPicker",
-	inputWrapper: "dw-TaxonomyPicker-container"
+	inputWrapper: "dw-TaxonomyPicker-container",
+	errorMessage: "dw-TaxonomyPicker-errorMessage",
+	successMessage: "dw-TaxonomyPicker-successMessage"
 };
 
 export const getStyles = (props: ITaxonomyPickerStyleProps): ITaxonomyPickerStyles => {
-	const { className } = props;
+	const { className, theme } = props;
+	const { fonts, semanticColors } = theme;
 	const classNames = GlobalClassNames;
 
 	return {
@@ -21,6 +25,30 @@ export const getStyles = (props: ITaxonomyPickerStyleProps): ITaxonomyPickerStyl
 		input: [
 			{
 				flexGrow: 1
+			}
+		],
+		errorMessage: [
+			classNames.errorMessage,
+			AnimationClassNames.slideDownIn20,
+			fonts.small,
+			{
+				color: semanticColors.errorText,
+				margin: 0,
+				paddingTop: 5,
+				display: "flex",
+				alignItems: "center"
+			}
+		],
+		successMessage: [
+			classNames.errorMessage,
+			AnimationClassNames.slideDownIn20,
+			fonts.small,
+			{
+				color: semanticColors.successText,
+				margin: 0,
+				paddingTop: 5,
+				display: "flex",
+				alignItems: "center"
 			}
 		]
 	};

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -1,5 +1,5 @@
 import { ILabelProps } from "office-ui-fabric-react/lib/Label";
-import { IStyle } from "office-ui-fabric-react/lib/Styling";
+import { IStyle, ITheme } from "office-ui-fabric-react/lib/Styling";
 import { IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
 import { ITermValue } from "../../models";
 import { ITaxonomyProvider } from "./providers";
@@ -34,15 +34,35 @@ export interface ITaxonomyPickerProps {
 	 */
 	styles?: IStyleFunctionOrObject<ITaxonomyPickerStyleProps, ITaxonomyPickerStyles>;
 
+	theme?: ITheme;
+
 	onChange(items: ITermValue[]): void;
+
+	/**
+	 * When specified, allows to override the error message that is being set.
+	 * This allows you to display a different message - or none at all - when an error is returned.
+	 * @param err The current error that is being thrown.
+	 */
+	onGetErrorMessage?(err: string): string | JSX.Element;
+
+	/**
+	 * When specified, allows to override the success message that is being set.
+	 * This allows you to display a different message - or none at all - when a new term has been created.
+	 * @param message The current message that is being returned.
+	 * @param newValue The name of the term that has been added.
+	 */
+	onGetSuccessMessage?(message: string, newValue: string): string | JSX.Element;
 }
 
 export interface ITaxonomyPickerStyleProps {
 	className?: string;
+	theme: ITheme;
 }
 
 export interface ITaxonomyPickerStyles {
 	taxonomyPicker?: IStyle;
 	inputWrapper?: IStyle;
 	input?: IStyle;
+	errorMessage?: IStyle;
+	successMessage?: IStyle;
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -6,6 +6,8 @@ import { ITaxonomyProvider } from "./providers";
 import { ITaxonomyPickerDialogProps } from "./TaxonomyPickerDialog.types";
 
 export interface ITaxonomyPickerProps {
+	allowAddingTerms?: boolean;
+
 	provider: ITaxonomyProvider;
 
 	itemLimit?: number;

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
@@ -205,6 +205,10 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 		return result;
 	};
 
+	const handleCancelTermCreation = (): void => {
+		setTermCreatingParentId(undefined);
+	};
+
 	const renderTreeView = (): JSX.Element | null => {
 		if (!showRootNode && !termTreeItems?.length) {
 			return null;
@@ -269,7 +273,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 				<TermAdder
 					key={`${termCreatingParentId}_${term.key}`}
 					onSubmit={handleCreateNewTerm}
-					onCancel={() => setTermCreatingParentId(undefined)}
+					onCancel={handleCancelTermCreation}
 					labels={labels.termAdderLabels}
 				/>
 			);

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
@@ -150,12 +150,15 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 	const handleStartCreateNewTermAction = (nodeId: string): void => {
 		setTermCreatingParentId(nodeId);
 
-		if (expandedNodes.indexOf(nodeId) === -1) {
-			const newExpanded = expandedNodes || [];
-			newExpanded.push(nodeId);
+		setExpandedNodes((current) => {
+			const newExpanded = [...current];
 
-			setExpandedNodes(newExpanded);
-		}
+			if (current.indexOf(nodeId) === -1) {
+				newExpanded.push(nodeId);
+			}
+
+			return newExpanded;
+		});
 	};
 
 	const handleNodeToggle = (ev: React.ChangeEvent, nodeIds?: string[]): void => {

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
@@ -56,9 +56,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 	const [flattenedTermTreeItems, setFlattenedTermTreeItems] = React.useState<ITerm[] | undefined>(undefined);
 	const [selectedTreeNode, setSelectedTreeNode] = React.useState<ITerm | undefined>(undefined);
 	const [termCreatingParentId, setTermCreatingParentId] = React.useState<string | undefined>(undefined);
-	const [expandedNodes, setExpandedNodes] = React.useState<string[]>([
-		showRootNode ? rootNodeKey : termTreeItems![0].key
-	]);
+	const [expandedNodes, setExpandedNodes] = React.useState<string[]>([]);
 	const [selectedTreeItem, setSelectedTreeItem] = React.useState<string | null>(null);
 	const treeItemActions = React.useRef<ITreeItemAction[]>([]);
 
@@ -81,6 +79,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			const terms = await provider.getTermTree();
 
 			setTermTreeItems(terms);
+			setExpandedNodes(showRootNode ? [rootNodeKey] : terms && terms.length > 0 ? [terms[0].key] : []);
 		})();
 	}, [provider]);
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.test.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.test.tsx
@@ -27,6 +27,19 @@ describe("<TaxonomyPickerDialog />", () => {
 			expect(await screen.findByText(/Add/i)).toBeTruthy();
 		});
 
+		it("should render without crashing when allowing adding of terms", async () => {
+			render(
+				<TaxonomyPickerDialog
+					provider={mockTaxonomyProvider}
+					hidden={false}
+					pickerProps={{ onResolveSuggestions: onResolveSuggestions }}
+					allowAddingTerms={true}
+				/>
+			);
+
+			expect(await screen.findByText(/Add/i)).toBeTruthy();
+		});
+
 		it("should be able to render custom labels", async () => {
 			render(
 				<TaxonomyPickerDialog

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.test.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.test.tsx
@@ -10,7 +10,7 @@ const onResolveSuggestions = async (filter: string, currentSelection?: ITerm[]):
 
 	return availableItems
 		.filter((it) => it.name.toLocaleLowerCase().indexOf(filter.toLocaleLowerCase()) !== -1)
-		.filter((it) => currentSelection?.filter((si) => si.key === it.key).length === 0);
+		.filter((it) => !currentSelection?.some((si) => si.key === it.key));
 };
 
 describe("<TaxonomyPickerDialog />", () => {

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.types.ts
@@ -44,7 +44,7 @@ interface ITaxonomyPickerDialogPropsBase {
 
 	onConfirm?(terms?: ITermValue[]): void;
 
-	onCreateNewTerm?(parentNodeId: string, newValue: string): PromiseLike<void | ITermCreationResult>;
+	onCreateNewTerm?(newValue: string, parentId?: string): PromiseLike<void | ITermCreationResult>;
 }
 
 export type ITaxonomyPickerDialogProps = ITaxonomyPickerDialogPropsBase & IDialogProps;

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.types.ts
@@ -1,21 +1,27 @@
 import { IDialogProps } from "office-ui-fabric-react/lib/Dialog";
 import { IStyle, ITheme } from "office-ui-fabric-react/lib/Styling";
 import { IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
-import { ITermValue } from "../../models";
+import { ITermCreationResult, ITermValue } from "../../models";
 import { ITermPickerProps } from "../TermPicker";
 import { ITaxonomyProvider } from "./providers";
+import { ITermAdderLabels } from "./TermAdder";
 
 export interface ITaxonomyPickerDialogLabels {
 	okButton?: string;
 	cancelButton?: string;
 	addButton?: string;
 	replaceButton?: string;
+	addNewTermAction?: string;
+	termAdderLabels?: ITermAdderLabels;
 }
 
 interface ITaxonomyPickerDialogPropsBase {
+	allowAddingTerms?: boolean;
+
 	provider: ITaxonomyProvider;
 
 	showRootNode?: boolean;
+
 	rootNodeLabel?: string;
 
 	defaultSelectedItems?: ITermValue[];
@@ -37,6 +43,8 @@ interface ITaxonomyPickerDialogPropsBase {
 	theme?: ITheme;
 
 	onConfirm?(terms?: ITermValue[]): void;
+
+	onCreateNewTerm?(parentNodeId: string, newValue: string): PromiseLike<void | ITermCreationResult>;
 }
 
 export type ITaxonomyPickerDialogProps = ITaxonomyPickerDialogPropsBase & IDialogProps;

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.base.tsx
@@ -1,0 +1,84 @@
+import { IconButton, Spinner, SpinnerSize, TextField } from "office-ui-fabric-react";
+import { classNamesFunction } from "office-ui-fabric-react/lib/Utilities";
+import * as React from "react";
+import { useStateIfMounted } from "../../../utils/useStateIfMounted";
+import { ITermAdderLabels, ITermAdderProps, ITermAdderStyleProps, ITermAdderStyles } from "./TermAdder.types";
+
+const getClassNames = classNamesFunction<ITermAdderStyleProps, ITermAdderStyles>();
+
+export const TermAdderBase: React.FC<ITermAdderProps> = React.forwardRef<HTMLFormElement, ITermAdderProps>(
+	(props, ref) => {
+		const { labels: labelsProp, onCancel, onSubmit, styles, className, theme } = props;
+
+		const [inputValue, setInputValue] = React.useState<string | undefined>(undefined);
+		const [errorMessage, setErrorMessage] = useStateIfMounted<string | undefined>(undefined);
+		const [isSaving, setIsSaving] = useStateIfMounted(false);
+
+		const defaultLabels: ITermAdderLabels = {
+			fieldRequiredMessage: "Please enter a value."
+		};
+
+		const labels = { ...defaultLabels, ...labelsProp };
+
+		const classNames = getClassNames(styles, { className, theme: theme! });
+
+		const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
+			ev.preventDefault();
+
+			if (!inputValue || inputValue.length === 0) {
+				setErrorMessage(labels.fieldRequiredMessage);
+				return;
+			}
+
+			if (onSubmit) {
+				setIsSaving(true);
+
+				const result = await onSubmit(inputValue);
+
+				if (typeof result === "object" && !result.success) {
+					setErrorMessage(result.error);
+				} else {
+					setErrorMessage(undefined);
+				}
+
+				setIsSaving(false);
+			}
+		};
+
+		const handleCancel = (ev: React.MouseEvent<HTMLButtonElement>): void => {
+			if (onCancel) {
+				onCancel();
+			}
+		};
+
+		const handleInputChange = (ev: React.FormEvent<HTMLInputElement>, newValue?: string): void => {
+			setInputValue(newValue);
+		};
+
+		return (
+			<form ref={ref} className={classNames.termAdder} onSubmit={handleSubmit}>
+				<TextField
+					autoFocus={true}
+					className={classNames.textField}
+					errorMessage={errorMessage}
+					onChange={handleInputChange}
+					underlined={true}
+					value={inputValue}
+				/>
+
+				{isSaving ? (
+					<Spinner size={SpinnerSize.xSmall} className={classNames.spinner} />
+				) : (
+					<>
+						<IconButton iconProps={{ iconName: "StatusCircleCheckmark" }} className={classNames.button} type="submit" />
+						<IconButton
+							iconProps={{ iconName: "StatusCircleErrorX" }}
+							className={classNames.button}
+							onClick={handleCancel}
+						/>
+					</>
+				)}
+			</form>
+		);
+	}
+);

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.styles.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.styles.ts
@@ -1,0 +1,46 @@
+import { ITermAdderStyleProps, ITermAdderStyles } from "./TermAdder.types";
+
+const GlobalClassNames = {
+	termAdder: "dw-TermAdder",
+	textField: "dw-TermAdderField",
+	button: "dw-TermAdderButton",
+	spinner: "dw-TermAdderSpinner"
+};
+
+export const getStyles = (props: ITermAdderStyleProps): ITermAdderStyles => {
+	const { className } = props;
+	const classNames = GlobalClassNames;
+
+	return {
+		termAdder: [
+			classNames.termAdder,
+			{
+				display: "flex",
+				marginLeft: "22px"
+			},
+			className
+		],
+
+		textField: [
+			classNames.textField,
+			{
+				maxWidth: "175px"
+			}
+		],
+
+		button: [
+			classNames.button,
+			{
+				width: "24px"
+			}
+		],
+
+		spinner: [
+			classNames.spinner,
+			{
+				height: "32px",
+				width: "24px"
+			}
+		]
+	};
+};

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.test.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { TermAdder } from "./TermAdder";
+
+describe("<TermAdder />", () => {
+	describe("Rendering", () => {
+		it("should render without crashing", async () => {
+			const { container } = render(<TermAdder />);
+
+			expect(container.querySelector("input[type='Text']")).toBeTruthy();
+		});
+	});
+
+	describe("Events", () => {
+		it("should show error when submitting empty value", async () => {
+			const handleSubmit = jest.fn();
+
+			const { container } = render(<TermAdder onSubmit={handleSubmit} />);
+
+			const input = container.getElementsByTagName("input")[0];
+			const form = container.getElementsByTagName("form")[0];
+
+			fireEvent.change(input, { target: { value: "" } });
+			fireEvent.submit(form);
+
+			expect(await screen.findByText("Please enter a value.")).toBeTruthy();
+			expect(handleSubmit).toBeCalledTimes(0);
+		});
+
+		it("should call onSubmit when submitting form", async () => {
+			const handleSubmit = jest.fn();
+
+			const { container } = render(<TermAdder onSubmit={handleSubmit} />);
+
+			const input = container.getElementsByTagName("input")[0];
+			const form = container.getElementsByTagName("form")[0];
+
+			const inputValue = "Test value";
+
+			userEvent.type(input, inputValue);
+			fireEvent.submit(form);
+
+			waitFor(
+				() => {
+					// make sure form submission is complete
+				},
+				{ container }
+			);
+
+			expect(handleSubmit).toBeCalledTimes(1);
+			expect(handleSubmit).toBeCalledWith(inputValue);
+		});
+	});
+});

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.tsx
@@ -1,0 +1,10 @@
+import { styled } from "office-ui-fabric-react/lib/Utilities";
+import * as React from "react";
+import { TermAdderBase } from "./TermAdder.base";
+import { getStyles } from "./TermAdder.styles";
+import { ITermAdderProps, ITermAdderStyleProps, ITermAdderStyles } from "./TermAdder.types";
+
+export const TermAdder: React.FC<ITermAdderProps> = styled<ITermAdderProps, ITermAdderStyleProps, ITermAdderStyles>(
+	TermAdderBase,
+	getStyles
+);

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/TermAdder.types.ts
@@ -1,0 +1,48 @@
+import { IStyle, ITheme } from "office-ui-fabric-react/lib/Styling";
+import { IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
+import { ITermCreationResult } from "../../../models";
+
+export interface ITermAdderLabels {
+	fieldRequiredMessage?: string;
+}
+
+export interface ITermAdderProps {
+	labels?: ITermAdderLabels;
+
+	/**
+	 * Callback for when the save button is clicked
+	 */
+	onSubmit?(value?: string): void | PromiseLike<void | ITermCreationResult>;
+
+	/**
+	 * Callback for when the cancel button is clicked
+	 */
+	onCancel?(): void;
+
+	/**
+	 * Optional class for the root TreeItem element
+	 */
+	className?: string;
+
+	/**
+	 * Call to apply custom styling on the TreeItem element
+	 */
+	styles?: IStyleFunctionOrObject<ITermAdderStyleProps, ITermAdderStyles>;
+
+	/**
+	 * The current theme applied to the control
+	 */
+	theme?: ITheme;
+}
+
+export interface ITermAdderStyleProps {
+	className?: string;
+	theme: ITheme;
+}
+
+export interface ITermAdderStyles {
+	termAdder?: IStyle;
+	textField?: IStyle;
+	button?: IStyle;
+	spinner?: IStyle;
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/index.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TermAdder/index.ts
@@ -1,0 +1,3 @@
+export * from "./TermAdder";
+export * from "./TermAdder.base";
+export * from "./TermAdder.types";

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/index.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/index.ts
@@ -5,3 +5,4 @@ export * from "./TaxonomyPicker.types";
 export * from "./TaxonomyPickerDialog";
 export * from "./TaxonomyPickerDialog.base";
 export * from "./TaxonomyPickerDialog.types";
+export * from "./TermAdder";

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/providers/ITaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/providers/ITaxonomyProvider.ts
@@ -4,4 +4,6 @@ export interface ITaxonomyProvider {
 	getTerms(): ITerm[] | PromiseLike<ITerm[]>;
 
 	getTermTree(): ITerm[] | PromiseLike<ITerm[]>;
+
+	createTerm(parentId: string, newValue: string): ITerm | PromiseLike<ITerm>;
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/providers/ITaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/providers/ITaxonomyProvider.ts
@@ -1,9 +1,11 @@
 import { ITerm } from "../../../models";
 
 export interface ITaxonomyProvider {
+	termValidationRegex?: RegExp;
+
 	getTerms(): ITerm[] | PromiseLike<ITerm[]>;
 
 	getTermTree(): ITerm[] | PromiseLike<ITerm[]>;
 
-	createTerm(parentId: string, newValue: string): ITerm | PromiseLike<ITerm>;
+	createTerm(newValue: string, parentId?: string): ITerm | PromiseLike<ITerm>;
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
@@ -2,7 +2,7 @@ import { ITerm } from "../../../models/ITerm";
 import { ITaxonomyProvider } from "./ITaxonomyProvider";
 
 export class MockTaxonomyProvider implements ITaxonomyProvider {
-	public getTerms(): ITerm[] | PromiseLike<ITerm[]> {
+	public getTerms(): ITerm[] | Promise<ITerm[]> {
 		return [
 			{ key: "bf0b202c-1dde-4088-ae7a-2163189f3d6c", name: "My term A" },
 			{ key: "bfa97857-b8af-4cbd-b363-86a05ec669b3", name: "My term B" },
@@ -13,7 +13,7 @@ export class MockTaxonomyProvider implements ITaxonomyProvider {
 		];
 	}
 
-	public getTermTree(): ITerm[] | PromiseLike<ITerm[]> {
+	public getTermTree(): ITerm[] | Promise<ITerm[]> {
 		return [
 			{
 				key: "bf0b202c-1dde-4088-ae7a-2163189f3d6c",
@@ -34,5 +34,20 @@ export class MockTaxonomyProvider implements ITaxonomyProvider {
 				children: [{ key: "95a73605-0793-4843-99ae-20c23aae6fff", name: "The best term in the world" }]
 			}
 		];
+	}
+
+	public async createTerm(parentId: string, newValue: string): Promise<ITerm> {
+		var uuid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+			var r = (Math.random() * 16) | 0,
+				v = c == "x" ? r : (r & 0x3) | 0x8;
+			return v.toString(16);
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 750));
+
+		return {
+			key: uuid,
+			name: newValue
+		};
 	}
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
@@ -1,53 +1,70 @@
 import { ITerm } from "../../../models/ITerm";
+import { CollectionUtils } from "../../../utils";
 import { ITaxonomyProvider } from "./ITaxonomyProvider";
 
 export class MockTaxonomyProvider implements ITaxonomyProvider {
+	public termValidationRegex = /^[^;"<>|\t\n\r]{1,255}$/gi;
+
+	private _termTree: ITerm[] = [
+		{
+			key: "bf0b202c-1dde-4088-ae7a-2163189f3d6c",
+			name: "My term A",
+			disabled: true,
+			children: [
+				{
+					key: "50724d2c-b2fd-4eba-8285-7db8cbf71d43",
+					name: "Another term",
+					children: [{ key: "c9ac78c6-90df-4f4a-841c-9bba7a85566e", name: "The term of test" }]
+				},
+				{ key: "f00e2959-5dde-4bdc-a6bd-6df22b095025", name: "Yet another term" }
+			]
+		},
+		{
+			key: "bfa97857-b8af-4cbd-b363-86a05ec669b3",
+			name: "My term B",
+			children: [{ key: "95a73605-0793-4843-99ae-20c23aae6fff", name: "The best term in the world" }]
+		}
+	];
+
 	public getTerms(): ITerm[] | Promise<ITerm[]> {
-		return [
-			{ key: "bf0b202c-1dde-4088-ae7a-2163189f3d6c", name: "My term A" },
-			{ key: "bfa97857-b8af-4cbd-b363-86a05ec669b3", name: "My term B" },
-			{ key: "50724d2c-b2fd-4eba-8285-7db8cbf71d43", name: "Another term" },
-			{ key: "f00e2959-5dde-4bdc-a6bd-6df22b095025", name: "Yet another term" },
-			{ key: "c9ac78c6-90df-4f4a-841c-9bba7a85566e", name: "The term of test" },
-			{ key: "95a73605-0793-4843-99ae-20c23aae6fff", name: "The best term in the world" }
-		];
+		return new Promise((resolve) => setTimeout(() => resolve(CollectionUtils.flatten(this._termTree)), 500));
 	}
 
 	public getTermTree(): ITerm[] | Promise<ITerm[]> {
-		return [
-			{
-				key: "bf0b202c-1dde-4088-ae7a-2163189f3d6c",
-				name: "My term A",
-				disabled: true,
-				children: [
-					{
-						key: "50724d2c-b2fd-4eba-8285-7db8cbf71d43",
-						name: "Another term",
-						children: [{ key: "c9ac78c6-90df-4f4a-841c-9bba7a85566e", name: "The term of test" }]
-					},
-					{ key: "f00e2959-5dde-4bdc-a6bd-6df22b095025", name: "Yet another term" }
-				]
-			},
-			{
-				key: "bfa97857-b8af-4cbd-b363-86a05ec669b3",
-				name: "My term B",
-				children: [{ key: "95a73605-0793-4843-99ae-20c23aae6fff", name: "The best term in the world" }]
-			}
-		];
+		return this._termTree;
 	}
 
-	public async createTerm(parentId: string, newValue: string): Promise<ITerm> {
-		var uuid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-			var r = (Math.random() * 16) | 0,
-				v = c == "x" ? r : (r & 0x3) | 0x8;
+	public async createTerm(newValue: string, parentId?: string): Promise<ITerm> {
+		const uuid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+			const r = Math.random() * 16 || 0,
+				v = c === "x" ? r : (r && 0x3) || 0x8;
 			return v.toString(16);
 		});
 
-		await new Promise((resolve) => setTimeout(resolve, 750));
+		return await new Promise((resolve, reject) => {
+			const parent: ITerm | undefined = !!parentId
+				? CollectionUtils.findInTree(this._termTree, (it) => it.key === parentId)
+				: undefined;
 
-		return {
-			key: uuid,
-			name: newValue
-		};
+			if (
+				(!parent && this._termTree.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())) ||
+				parent?.children?.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())
+			) {
+				reject("An error occured.");
+			} else {
+				const newTerm: ITerm = {
+					key: uuid,
+					name: newValue
+				};
+
+				if (!parentId || !parent) {
+					this._termTree.unshift(newTerm);
+				} else if (!!parent) {
+					parent.children?.unshift(newTerm);
+				}
+
+				resolve(newTerm);
+			}
+		});
 	}
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/providers/MockTaxonomyProvider.ts
@@ -42,29 +42,36 @@ export class MockTaxonomyProvider implements ITaxonomyProvider {
 		});
 
 		return await new Promise((resolve, reject) => {
-			const parent: ITerm | undefined = !!parentId
-				? CollectionUtils.findInTree(this._termTree, (it) => it.key === parentId)
-				: undefined;
-
-			if (
-				(!parent && this._termTree.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())) ||
-				parent?.children?.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())
-			) {
-				reject("An error occured.");
-			} else {
-				const newTerm: ITerm = {
-					key: uuid,
-					name: newValue
-				};
-
-				if (!parentId || !parent) {
-					this._termTree.unshift(newTerm);
-				} else if (!!parent) {
-					parent.children?.unshift(newTerm);
+			setTimeout(() => {
+				if (newValue === "test") {
+					reject(`Failed to add term '${newValue}'.`);
+					return;
 				}
 
-				resolve(newTerm);
-			}
+				const parent: ITerm | undefined = !!parentId
+					? CollectionUtils.findInTree(this._termTree, (it) => it.key === parentId)
+					: undefined;
+
+				if (
+					(!parent && this._termTree.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())) ||
+					parent?.children?.some((it) => it.name.toLocaleLowerCase() === newValue.toLocaleLowerCase())
+				) {
+					reject("An error occured.");
+				} else {
+					const newTerm: ITerm = {
+						key: uuid,
+						name: newValue
+					};
+
+					if (!parentId || !parent) {
+						this._termTree.unshift(newTerm);
+					} else if (!!parent) {
+						parent.children?.unshift(newTerm);
+					}
+
+					resolve(newTerm);
+				}
+			}, 750);
 		});
 	}
 }

--- a/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.base.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.base.tsx
@@ -8,10 +8,19 @@ import {
 
 const getClassNames = classNamesFunction<ITermItemSuggestionStyleProps, ITermItemSuggestionStyles>();
 
-export const TermItemSuggestionBase: React.FC<ITermItemSuggestionProps> = ({ children, styles, theme }) => {
+export const TermItemSuggestionBase: React.FC<ITermItemSuggestionProps> = ({ term, styles, theme }) => {
 	const classNames = getClassNames(styles, {
 		theme: theme!
 	});
 
-	return <div className={classNames.suggestionTextOverflow}> {children} </div>;
+	return (
+		<div className={classNames.root}>
+			<div>{term?.name}</div>
+			{term?.path && (
+				<div>
+					<small>{term?.path}</small>
+				</div>
+			)}
+		</div>
+	);
 };

--- a/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.styles.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.styles.ts
@@ -2,7 +2,7 @@ import { getGlobalClassNames } from "office-ui-fabric-react/lib/Styling";
 import { ITermItemSuggestionStyleProps, ITermItemSuggestionStyles } from "./TermItemSuggestion.types";
 
 const GlobalClassNames = {
-	suggestionTextOverflow: "ms-TermItem-TextOverflow"
+	root: "dw-TermSuggestion"
 };
 
 export function getStyles(props: ITermItemSuggestionStyleProps): ITermItemSuggestionStyles {
@@ -11,14 +11,19 @@ export function getStyles(props: ITermItemSuggestionStyleProps): ITermItemSugges
 	const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
 	return {
-		suggestionTextOverflow: [
-			classNames.suggestionTextOverflow,
+		root: [
+			classNames.root,
 			{
-				overflow: "hidden",
-				textOverflow: "ellipsis",
 				maxWidth: "60vw",
 				padding: "6px 12px 7px",
-				whiteSpace: "nowrap"
+				textAlign: "left",
+				selectors: {
+					"> div": {
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap"
+					}
+				}
 			},
 			className
 		]

--- a/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.types.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion.types.ts
@@ -1,7 +1,10 @@
 import { IStyle, ITheme } from "office-ui-fabric-react/lib/Styling";
 import { IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
+import { ITermValue } from "../../models";
 
 export interface ITermItemSuggestionProps extends React.AllHTMLAttributes<HTMLElement> {
+	term?: ITermValue;
+
 	/**
 	 * Optional class for the root TaxonomyPicker element
 	 */
@@ -22,8 +25,5 @@ export type ITermItemSuggestionStyleProps = Required<Pick<ITermItemSuggestionPro
 	Pick<ITermItemSuggestionProps, "className"> & {};
 
 export interface ITermItemSuggestionStyles {
-	/**
-	 * Refers to the text element of the TermItemSuggestion
-	 */
-	suggestionTextOverflow?: IStyle;
+	root?: IStyle;
 }

--- a/packages/dw-react-controls/src/components/TermPicker/TermPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermPicker.base.tsx
@@ -8,9 +8,14 @@ import { TermItemSuggestion } from "./TermItemSuggestion";
 import { ITermPickerProps } from "./TermPicker.types";
 
 export class TermPickerBase extends BasePicker<ITermValue, ITermPickerProps> {
-	public static defaultProps = {
+	public static defaultProps: Partial<ITermPickerProps> = {
 		onRenderItem: (props: IPickerItemProps<ITermValue>) => <TermItem {...props}>{props.item.name}</TermItem>,
-		onRenderSuggestionsItem: (props: ITermValue) => <TermItemSuggestion {...props}>{props.name}</TermItemSuggestion>
+		onRenderSuggestionsItem: (props: ITermValue) => <TermItemSuggestion term={props} />,
+		pickerSuggestionsProps: {
+			loadingText: "Searching...",
+			noResultsFoundText: "No results found.",
+			suggestionsHeaderText: "Suggested terms"
+		}
 	};
 
 	constructor(props: ITermPickerProps) {

--- a/packages/dw-react-controls/src/components/TermPicker/TermPicker.stories.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermPicker.stories.tsx
@@ -18,7 +18,7 @@ storiesOf("TermPicker", module)
 		): ITermValue[] | PromiseLike<ITermValue[]> => {
 			return items
 				.filter((it) => it.name.toLocaleLowerCase().indexOf(filter.toLocaleLowerCase()) !== -1)
-				.filter((it) => selectedItems?.filter((si) => si.key === it.key).length === 0);
+				.filter((it) => !selectedItems?.some((si) => si.key === it.key));
 		};
 
 		return <TermPicker onResolveSuggestions={onResolveSuggestions} />;

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
@@ -3,6 +3,8 @@
  * Source code at https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/TreeItem/TreeItem.js
  */
 
+import { IconButton } from "office-ui-fabric-react/lib/Button";
+import { ContextualMenu, IContextualMenuItem } from "office-ui-fabric-react/lib/ContextualMenu";
 import { Icon } from "office-ui-fabric-react/lib/Icon";
 import { classNamesFunction, IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
 import * as React from "react";
@@ -20,6 +22,7 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 		label,
 		disabled,
 		iconName,
+		actions,
 		onClick,
 		onInvoke,
 		onRenderItemContents,
@@ -28,6 +31,9 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 		theme
 	} = props;
 	const { isExpanded, isSelected, selectNode, toggleExpansion } = React.useContext(TreeViewContext);
+
+	const contextMenuIconRef = React.useRef<HTMLDivElement>(null);
+	const [showContextMenu, setShowContextMenu] = React.useState(false);
 
 	const isExpandable = Array.isArray(children) ? !!children.length : !!children;
 	const expanded = isExpanded(nodeId);
@@ -60,6 +66,20 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 			onInvoke(event);
 		}
 	};
+
+	const handleContextMenuButtonClick = (event: React.MouseEvent<HTMLDivElement>): void => {
+		setShowContextMenu(true);
+	};
+
+	const handleHideContextMenu = (event: React.MouseEvent<HTMLElement>): void => {
+		setShowContextMenu(false);
+	};
+
+	const contextMenuActions: IContextualMenuItem[] =
+		actions?.map((action) => ({
+			...action,
+			onClick: () => (typeof action.onClick === "function" ? action.onClick(nodeId) : false)
+		})) || [];
 
 	const classNames = getClassNames(styles, { className, disabled, expanded, selected, theme: theme! });
 
@@ -101,6 +121,24 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 				</div>
 
 				{finalOnRenderItemContents({ disabled, selected, expanded, label, iconName })}
+
+				{actions && actions.length > 0 && (
+					<div ref={contextMenuIconRef} className={classNames.contextMenuIconWrapper}>
+						<IconButton
+							className={classNames.contextMenuIcon}
+							onClick={handleContextMenuButtonClick}
+							iconProps={{ iconName: "More" }}
+						/>
+					</div>
+				)}
+
+				{showContextMenu && (
+					<ContextualMenu
+						items={contextMenuActions}
+						onDismiss={handleHideContextMenu}
+						target={contextMenuIconRef.current}
+					/>
+				)}
 			</div>
 
 			{expanded && children && (

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.styles.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.styles.ts
@@ -4,6 +4,8 @@ import { ITreeItemStyleProps, ITreeItemStyles } from "./TreeItem.types";
 const GlobalClassNames = {
 	treeItem: "dw-TreeItem",
 	treeNode: "dw-TreeNode",
+	contextMenuIconWrapper: "dw-TreeItemContextMenuIconWrapper",
+	contextMenuIcon: "dw-TreeItemContextMenuIcon",
 	expandIconWrapper: "dw-TreeExpandIconWrapper",
 	expandIcon: "dw-TreeExpandIcon",
 	childNodes: "dw-TreeNodeChildren",
@@ -48,6 +50,15 @@ export const getStyles = (props: ITreeItemStyleProps): ITreeItemStyles => {
 				}
 			}
 		],
+
+		contextMenuIconWrapper: [
+			classNames.contextMenuIconWrapper,
+			{
+				marginLeft: selected ? "3px" : "4px"
+			}
+		],
+
+		contextMenuIcon: [classNames.contextMenuIcon],
 
 		expandIconWrapper: [
 			classNames.expandIconWrapper,

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
@@ -14,6 +14,11 @@ export interface ITreeItemProps {
 	label: string;
 
 	/**
+	 * Actions which are available on the tree item
+	 */
+	actions?: ITreeItemAction[];
+
+	/**
 	 * Controls whether the tree item can be selected
 	 */
 	disabled?: boolean;
@@ -65,6 +70,8 @@ export interface ITreeItemStyleProps {
 export interface ITreeItemStyles {
 	treeItem?: IStyle;
 	treeNode?: IStyle;
+	contextMenuIconWrapper?: IStyle;
+	contextMenuIcon?: IStyle;
 	expandIconWrapper?: IStyle;
 	expandIcon?: IStyle;
 	itemWrapper?: IStyle;
@@ -73,4 +80,10 @@ export interface ITreeItemStyles {
 	labelWrapper?: IStyle;
 	label?: IStyle;
 	childNodes?: IStyle;
+}
+
+export interface ITreeItemAction {
+	key: string;
+	text: string;
+	onClick?(nodeId: string): void;
 }

--- a/packages/dw-react-controls/src/components/TreeView/TreeView.types.ts
+++ b/packages/dw-react-controls/src/components/TreeView/TreeView.types.ts
@@ -20,7 +20,7 @@ export interface ITreeViewProps {
 	/**
 	 * Selected node id (controlled)
 	 */
-	selected?: string;
+	selected?: string | null;
 
 	/**
 	 * Optional class for the root TreeView element

--- a/packages/dw-react-controls/src/models/ITermSubmissionResult.ts
+++ b/packages/dw-react-controls/src/models/ITermSubmissionResult.ts
@@ -1,0 +1,7 @@
+import { ITerm } from "./ITerm";
+
+export interface ITermCreationResult {
+	success: boolean;
+	newTerm?: ITerm;
+	error?: string;
+}

--- a/packages/dw-react-controls/src/models/index.ts
+++ b/packages/dw-react-controls/src/models/index.ts
@@ -1,2 +1,3 @@
 export * from "./ITerm";
+export * from "./ITermSubmissionResult";
 export * from "./ITermValue";

--- a/packages/dw-react-controls/src/utils/asyncUtils.ts
+++ b/packages/dw-react-controls/src/utils/asyncUtils.ts
@@ -1,0 +1,14 @@
+export namespace AsyncUtils {
+	export const actAsSync = (fn: () => Generator<unknown, any, unknown>) => {
+		const iterator = fn();
+		const loop = (result: any) => {
+			!result.done &&
+				result.value.then(
+					(res: any) => loop(iterator.next(res)),
+					(err: any) => loop(iterator.throw(err))
+				);
+		};
+
+		loop(iterator.next());
+	};
+}

--- a/packages/dw-react-controls/src/utils/collectionUtils.ts
+++ b/packages/dw-react-controls/src/utils/collectionUtils.ts
@@ -12,4 +12,23 @@ export namespace CollectionUtils {
 
 		return result;
 	};
+
+	export const findInTree = <T extends { children?: T[] }>(
+		arr: T[],
+		predicate: (value: T) => boolean
+	): T | undefined => {
+		for (let index = 0; index < arr.length; index++) {
+			const term = arr[index];
+
+			if (predicate(term)) {
+				return term;
+			} else if (!!term.children && term.children.length > 0) {
+				const match = findInTree(term.children, predicate);
+
+				if (match) {
+					return match;
+				}
+			}
+		}
+	};
 }

--- a/packages/dw-react-controls/src/utils/index.ts
+++ b/packages/dw-react-controls/src/utils/index.ts
@@ -1,2 +1,4 @@
 export * from "./collectionUtils";
 export * from "./useControlled";
+export * from "./useIsMounted";
+export * from "./useStateIfMounted";

--- a/packages/dw-react-controls/src/utils/useControlled.ts
+++ b/packages/dw-react-controls/src/utils/useControlled.ts
@@ -5,7 +5,12 @@ export const useControlled: <T>(
 	defaultProp: T,
 	name: string,
 	state?: string
-) => [T, (newValue: T) => void] = <T>(controlled: T, defaultProp: T, name: string, state: string = "value") => {
+) => [T, (newValue: React.SetStateAction<T>) => void] = <T>(
+	controlled: T,
+	defaultProp: T,
+	name: string,
+	state: string = "value"
+) => {
 	const { current: isControlled } = React.useRef(controlled !== undefined);
 	const [valueState, setValue] = React.useState(defaultProp);
 	const value = isControlled ? controlled : valueState;
@@ -41,7 +46,7 @@ export const useControlled: <T>(
 		}, [JSON.stringify(defaultProp)]);
 	}
 
-	const setValueIfUncontrolled = React.useCallback((newValue: T) => {
+	const setValueIfUncontrolled = React.useCallback((newValue: React.SetStateAction<T>) => {
 		if (!isControlled) {
 			setValue(newValue);
 		}

--- a/packages/dw-react-controls/src/utils/useIsMounted.ts
+++ b/packages/dw-react-controls/src/utils/useIsMounted.ts
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+export const useIsMounted: () => React.MutableRefObject<boolean> = () => {
+	const isMounted = React.useRef(false);
+
+	React.useEffect(() => {
+		isMounted.current = true;
+
+		return () => {
+			isMounted.current = false;
+		};
+	}, []);
+
+	return isMounted;
+};

--- a/packages/dw-react-controls/src/utils/useStateIfMounted.ts
+++ b/packages/dw-react-controls/src/utils/useStateIfMounted.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { useIsMounted } from "./useIsMounted";
+
+export const useStateIfMounted: <T>(initialState?: T) => [T | undefined, (newValue?: T) => void] = <T>(
+	initialState?: T
+) => {
+	const isComponentMounted = useIsMounted();
+	const [state, setState] = React.useState(initialState);
+
+	const newSetState = (value: T | undefined) => {
+		if (isComponentMounted.current) {
+			setState(value);
+		}
+	};
+
+	return [state, newSetState];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -3120,6 +3127,13 @@
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.26.0"
+
+"@testing-library/user-event@^13.1.9":
+  version "13.1.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.1.9.tgz#29e49a42659ac3c1023565ff56819e0153a82e99"
+  integrity sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/anymatch@*":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12201,6 +12201,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 riceburn@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/riceburn/-/riceburn-1.3.1.tgz#c9b0685b31c8b3ac9d06c462edd71dddc1d936d7"


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Added the option to add terms in the `TaxonomyPickerDialog`.
Now possible to add actions to a TreeItem, which appear in the item's contextual menu.
