### PR TITLE
[TaxonomyPicker] Potential issue with updating context menu actions

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-555c0613-5137-4d55-b735-c0676e8fa61e.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-555c0613-5137-4d55-b735-c0676e8fa61e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix potential issue with updating context menu actions",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog.base.tsx
@@ -59,7 +59,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 	const [termCreatingParentId, setTermCreatingParentId] = React.useState<string | undefined>(undefined);
 	const [expandedNodes, setExpandedNodes] = React.useState<string[]>([]);
 	const [selectedTreeItem, setSelectedTreeItem] = React.useState<string | null>(null);
-	const treeItemActions = React.useRef<ITreeItemAction[]>([]);
+	const [treeItemActions, setTreeItemActions] = React.useState<ITreeItemAction[]>([]);
 
 	React.useEffect(() => {
 		const newTreeItemActions: ITreeItemAction[] = [];
@@ -72,7 +72,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			});
 		}
 
-		treeItemActions.current = newTreeItemActions;
+		setTreeItemActions(newTreeItemActions);
 	}, [allowAddingTerms]);
 
 	React.useEffect(() => {
@@ -237,7 +237,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 						label={rootNodeLabel || ""}
 						disabled={true}
 						iconName={"DocumentSet"}
-						actions={treeItemActions.current}
+						actions={treeItemActions}
 					>
 						{nodeTree}
 					</TreeItem>
@@ -287,7 +287,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 				disabled={term.disabled}
 				iconName={term.disabled ? "TagSolid" : "Tag"}
 				onInvoke={handleNodeInvoke}
-				actions={treeItemActions.current}
+				actions={treeItemActions}
 			>
 				{children}
 			</TreeItem>


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Save context menu items in state instead of ref, since updates might not be pushed through otherwise.
